### PR TITLE
Fix build on GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: "/ci"
+    schedule:
+      interval: daily
+      time: "06:00"
+      timezone: "America/Denver"
+
+    allow:
+      - dependency-type: all
+
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "Type: Maintenance"
+    commit-message:
+      prefix: "MNT: "
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+    allow:
+      - dependency-type: all
+
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "Type: Maintenance"
+    commit-message:
+      prefix: "MNT: "
+      include: "scope"

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -28,7 +28,10 @@ jobs:
       run: python -m pip install sphinx myst-parser pydata-sphinx-theme
 
     - name: Build docs
-      run: make html linkcheck
+      run: |
+        pushd site
+        make html linkcheck
+        popd
 
     - name: Upload docs as artifact
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build docs
       run: |
         pushd site
-        make html linkcheck
+        make html linkcheck O=-W
         popd
 
     - name: Upload docs as artifact

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -30,7 +30,16 @@ jobs:
     - name: Build docs
       run: |
         pushd site
-        make html linkcheck O=-W
+        make html O=-W
+        popd
+
+    # Need to do separately and remove these extra license files that get dumped into
+    # the build and cause warnings.
+    - name: Check links
+      run: |
+        pushd site
+        find build/html/_static -name LICENSE.md -delete
+        make linkcheck
         popd
 
     - name: Upload docs as artifact

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -24,8 +24,8 @@ jobs:
       with:
         python-version: 3.9
 
-    - name: Install dependencies (PyPI)
-      run: python -m pip install sphinx myst-parser pydata-sphinx-theme
+    - name: Install dependencies
+      run: python -m pip install -r ci/build_requirements.txt
 
     - name: Build docs
       run: |

--- a/ci/build_requirements.txt
+++ b/ci/build_requirements.txt
@@ -1,0 +1,3 @@
+sphinx==3.3.1
+pydata-sphinx-theme==0.4.1
+myst-parser==0.12.10


### PR DESCRIPTION
* Fix build caused by not being able to actually run action before (on initial GH Actions setup)
* Also pulled the build dependencies into `build_requirements.txt` and pin their versions to avoid random build breakage. Instead, set up Dependabot to manage those versions.
* Build with warnings as error