### PR TITLE
Add xesmf and xskillscore to environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,5 @@
    - boto3
    - jupyterlab
    - python-awips
+   - xesmf>=0.5.0
+   - xskillscore


### PR DESCRIPTION
Regridding (with xesmf) and verification metrics (with xskillscore) were planned as a part of the [Advanced Model Output vs. Observations](https://unidata.github.io/pyaos-ams-2021/projects/adv_model_vs_obs.html) project idea, so this adds those two packages to the environment list. xesmf (with ESMF) is a fairly hefty dependency, so hopefully that doesn't cause too many issues. At least v0.5.0 of xesmf is required so that we get automatic lat/lon coordinate identification.