### PR TITLE
Add small organization improvements to template

### DIFF
--- a/instructors/notebook-template/Template.ipynb
+++ b/instructors/notebook-template/Template.ipynb
@@ -17,7 +17,7 @@
     "<div style=\"clear:both\"></div>\n",
     "</div>\n",
     "\n",
-    "<hr style=\"height:2px;\">\n",
+    "---\n",
     "\n",
     "Along with your notebook, be sure to commit a small example output image from your code and link to it HERE (in the source), or link to an external image (logo, etc.) via URL. Remove this line after! Provide a brief `alt` text as well to benefit those with image display issues or potentially making use of screen readers.\n",
     "<div style=\"float:right; width:250 px\"><img src=\"../../instructors/images/Template_preview.png\" alt=\"sin(x) with few data points\" style=\"height: 300px;\"></div>\n",
@@ -39,13 +39,14 @@
     "1. [Here's #3](#3.-Objective,-the-third)\n",
     "1. [Final reminders and instructions for instructors](#Final-reminders)\n",
     "\n",
-    "<hr style=\"height:2px;\">"
+    "---"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Imports\n",
     "We will begin by importing the important packages to be used throughout! Instructors, generally keep your imports to before your objectives unless there is an important takeaway from what you're importing or the way you're doing it. Give a brief description if necessary in more introductory notebooks."
    ]
   },
@@ -63,6 +64,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 1. Your first objective\n"
    ]
   },
@@ -74,13 +82,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**NOTICE** copy this cell (after removing this text from source) to include at the end of any new sections you illustrate for a clear visual break and offer a path to the start of the notebook.\n",
+    "**NOTICE** copy this cell (after removing this text from source) to include at the end of any new sections you illustrate for a clear visual break and offer a path to the start of the notebook. You can use the markdown `---` separator to clearly separate your sections.\n",
     "\n",
     "<a href=\"#top\">Top</a>\n",
-    "<hr style=\"height:2px;\">"
+    "\n",
+    "---"
    ]
   },
   {
@@ -141,7 +157,8 @@
    "metadata": {},
    "source": [
     "<a href=\"#top\">Top</a>\n",
-    "<hr style=\"height:2px;\">"
+    "\n",
+    "---"
    ]
   },
   {
@@ -188,7 +205,8 @@
    "metadata": {},
    "source": [
     "<a href=\"#top\">Top</a>\n",
-    "<hr style=\"height:2px;\">"
+    "\n",
+    "---"
    ]
   },
   {
@@ -205,7 +223,8 @@
    "metadata": {},
    "source": [
     "<a href=\"#top\">Top</a>\n",
-    "<hr style=\"height:2px;\">"
+    "\n",
+    "---"
    ]
   },
   {


### PR DESCRIPTION
Quick PR per suggestions from @srcarter3. Use markdown `---` separators to remove some HTML for clarity for both contributors and users. Also explicitly add a subheaded section for imports before the first objective, as this got lost in the soup a bit and might confuse people following a notebook from top to bottom.