### PR TITLE
Add notebook that can update the workshop materials

### DIFF
--- a/.internal/update_workshop_material.ipynb
+++ b/.internal/update_workshop_material.ipynb
@@ -1,0 +1,115 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a name=\"top\"></a>\n",
+    "<div style=\"width:1000 px\">\n",
+    "\n",
+    "<div style=\"float:right; width:98 px; height:98px;\">\n",
+    "<img src=\"https://raw.githubusercontent.com/Unidata/MetPy/master/src/metpy/plots/_static/unidata_150x150.png\" alt=\"Unidata Logo\" style=\"height: 98px;\">\n",
+    "</div>\n",
+    "\n",
+    "<h1>Update Workshop Material</h1>\n",
+    "<h3>Unidata AMS 2021 Student Conference</h3>\n",
+    "\n",
+    "<div style=\"clear:both\"></div>\n",
+    "</div>\n",
+    "\n",
+    "---\n",
+    "\n",
+    "This notebook can be used to update the workshop training material whenever updates are posted.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Running the Update\n",
+    "\n",
+    "When you run the following cell, any changes from the workshop GitHub repository will be applied to the material under the `pyaos-ams-2021/` directory in your workspace.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gitpuller https://github.com/unidata/pyaos-ams-2021/ master pyaos-ams-2021"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## What to expect?\n",
+    "\n",
+    "If there are no updates to the material, the output from the cell will look something like the following:\n",
+    "\n",
+    "~~~bash\n",
+    "$ git fetch\n",
+    "\n",
+    "$ git -c user.email=nbgitpuller@nbgitpuller.link -c user.name=nbgitpuller merge -Xours origin/master\n",
+    "\n",
+    "Already up to date.\n",
+    "~~~\n",
+    "\n",
+    "If there are updates to the material, the output will look something like this:\n",
+    "\n",
+    "~~~bash\n",
+    "$ git fetch\n",
+    "\n",
+    "$ git -c user.email=nbgitpuller@nbgitpuller.link -c user.name=nbgitpuller merge -Xours origin/master\n",
+    "\n",
+    "Updating ae50798..9542ecf\n",
+    "\n",
+    "Fast-forward\n",
+    "\n",
+    " .../images/python-awips-upper-air-preview.png      | Bin 0 -> 90285 bytes\n",
+    "\n",
+    " .../python-awips-WorkingWithUpperAirObs.ipynb      | 326 +++++++++++\n",
+    "\n",
+    " site/index.md                                      |  47 +-\n",
+    "\n",
+    " 3 files changed, 371 insertions(+), 2 deletions(-)\n",
+    "\n",
+    " create mode 100644 instructors/images/python-awips-upper-air-preview.png\n",
+    "\n",
+    " create mode 100644 notebooks/visualization/python-awips-WorkingWithUpperAirObs.ipynb\n",
+    "~~~\n",
+    "\n",
+    "That's it!\n",
+    "Now you have the latest and greatest material for the workshop."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:pyaos-ams-2021]",
+   "language": "python",
+   "name": "conda-env-pyaos-ams-2021-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Add a notebook that users can run to update their copy of the workshop material without needing to run the command on the command line. The notebook lives in `.internal/`, and will ultimately be copied into the workshop participants top level user directory (one level up from the local git repository holding the workshop material).