### PR TITLE
Add xesmf to environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,5 @@
    - boto3
    - jupyterlab
    - python-awips
+   - xesmf>=0.5.0
+


### PR DESCRIPTION
While I had hoped to get regridding (with xesmf) and verification metrics (with xskillscore) as a part of the [Advanced Model Output vs. Observations](https://unidata.github.io/pyaos-ams-2021/projects/adv_model_vs_obs.html) project idea, xesmf has a problematic pin of xarray that conflicts with xskillscore, and it doesn't seem like it will be resolved upstream in time. Since regridding is probably the more useful demonstration, let's just go with xesmf.