### PR TITLE
Add xarray extra packages while disabling windows

### DIFF
--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS, windows, ubuntu]
+        os: [macOS, ubuntu]
 
     steps:
     - name: Checkout source

--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,8 @@
    - boto3
    - jupyterlab
    - python-awips
+   - xesmf>=0.5.0
+   - xskillscore
+   - cfgrib
+   - netcdf4
+


### PR DESCRIPTION
Third time's the charm I hope!

This PR attempts to add ~~three~~ four packages that are rather useful alongside xarray and which I plan to make use of in the xarray notebooks (xesmf, xskillscore, netcdf4-python, and cfgrib). Due to esmpy's windows incompatibility, this also requires removing the windows build.

One question: should I make mention of the fact that esmpy (and therefore xesmf) is not available on windows in the interpolation/regridding notebook?