### PR TITLE
Added matplotlib nbviewer links to resources and project pages & update agenda.md

### DIFF
--- a/site/agenda.md
+++ b/site/agenda.md
@@ -53,8 +53,12 @@ office hours will provide some structure to the otherwise nebulous nature of thi
 of the workshop.
 
 Office hours are also posted on the [Unidata Virtual AMS Booth
-page](https://www.unidata.ucar.edu/2021AMS). During office hours, you can [join the Airmeet video conference](https://www.airmeet.com/e/c30c2b30-4ab6-11eb-ae1f-335a915d8752)
+page](https://www.unidata.ucar.edu/2021AMS). 
+
+```{important}
+During office hours, you can [**join the Airmeet video conference**](https://www.airmeet.com/e/c30c2b30-4ab6-11eb-ae1f-335a915d8752)
 (or click the big button on the Unidata booth page).
+```
 
 ## Post AMS
 

--- a/site/projects/climate_timeseries.md
+++ b/site/projects/climate_timeseries.md
@@ -18,6 +18,7 @@ A 'deeper analysis' piece would have them identify dates where fronts came throu
 * [Numpy (basics)] (https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/analysis/numpy.ipynb)
 
 ### Visualization
-* Matplotlib basics
+* [Matplotlib: Basics](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/matplotlib-basics.ipynb)
+* [Matplotlib: Intermediate](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/matplotlib-intermediate.ipynb)
 
 ## Related MetPy Monday Videos

--- a/site/projects/intro_timeseries.md
+++ b/site/projects/intro_timeseries.md
@@ -18,8 +18,8 @@ Potentially include Pandas (e.g. basic dataframes, block averages, moving window
 * [Pandas (basics)] (https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/analysis/pandas.ipynb)
 
 ### Visualization
-* Matplotlib (basics)
-* Matplotlib (intermediate)
+* [Matplotlib: Basics](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/matplotlib-basics.ipynb)
+* [Matplotlib: Intermediate](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/matplotlib-intermediate.ipynb)
 
 ## Related Comprehensive Notebooks
 * [Basic Time Series Plotting](https://unidata.github.io/python-training/workshop/Time_Series/basic-time-series-plotting/)

--- a/site/projects/model_vs_obs.md
+++ b/site/projects/model_vs_obs.md
@@ -29,8 +29,8 @@ Highlight ways to enhance timeseries charts (time formatting on x-axis, latex la
 * xarray (interpolation)
 
 ### Visualization
-* Matplotlib (basics)
-* Matplotlib (intermediate)
+* [Matplotlib: Basics](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/matplotlib-basics.ipynb)
+* [Matplotlib: Intermediate](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/matplotlib-intermediate.ipynb)
 * [python-awips: Working with Maps and Topography Databases](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/python-awips-WorkingWithMapsTopoDatabases.ipynb)
 * [python-awips: Working with Models](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/python-awips-WorkingWithModels.ipynb)
 * [python-awips: Working with Surface Obs](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/python-awips-WorkingWithSurfaceObs.ipynb)

--- a/site/projects/plotting_satellite_data.md
+++ b/site/projects/plotting_satellite_data.md
@@ -22,7 +22,8 @@ This project seeks to enhance your current skillset by instructing you on how to
 * [python-awips: How to Access Data](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/dataAccess/python-awips-HowToAccessData.ipynb)
 
 ### Visualization
-* Matplotlib (intermediate)
+* [Matplotlib: Basics](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/matplotlib-basics.ipynb)
+* [Matplotlib: Intermediate](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/matplotlib-intermediate.ipynb)
 * Cartopy (basic)
 * Cartopy (intermediate)
 * [python-awips: Working with Maps and Topography Databases](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/python-awips-WorkingWithMapsTopoDatabases.ipynb)

--- a/site/projects/rossby_wave_analysis.md
+++ b/site/projects/rossby_wave_analysis.md
@@ -22,6 +22,7 @@ Allows application of existing calculations and implementation of own calculatio
 * MetPy (with xarray)
 
 ### Visualization
-* Matplotlib (basics)
+* [Matplotlib: Basics](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/matplotlib-basics.ipynb)
+* [Matplotlib: Intermediate](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/matplotlib-intermediate.ipynb)
 
 ## Related MetPy Monday Videos

--- a/site/resources.md
+++ b/site/resources.md
@@ -111,10 +111,10 @@ Resources
 
   _add description_
 
-* **Matplotlib: Basics**  
+* [**Matplotlib: Basics**](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/matplotlib-basics.ipynb)  
   This notebook covers the basics of how to use [matplotlib.pyplot](https://matplotlib.org/3.3.3/api/_as_gen/matplotlib.pyplot.html).  It describes the two main parts of the plot: the figure and axes.  The notebook walks through how to create simple line and scatter plots, how to modify the axes and titles, how to draw multiple data sets on the same graph, and how to alter the display settings for the data.
 
-* **Matplotlib: Intermediate**  
+* [**Matplotlib: Intermediate**](https://nbviewer.jupyter.org/github/Unidata/pyaos-ams-2021/blob/master/notebooks/visualization/matplotlib-intermediate.ipynb)  
   This notebook builds upon the Matlibplot: Basics notebook and details how to create more complicated plots.  It starts by describing how to draw multiple plots in one figure.  It also covers the scatter function and how it can be used to control the colorization of individual scatter points.  Finally, the notebook gives an introducton to imshow, contour, and contourf and how they can be used to visualize data.
 
 * MetPy (SkewT)


### PR DESCRIPTION
- added nbviewer preview page links for matplotlib training references
- will update these links once we have our own viewer pages for notebooks, but for now it's better to have nbviewer links than no links at all
- on the agenda page: bold the airmeet link and put it in an 'important' format box to make it stand out a little more