### PR TITLE
Small change to setup.md:

### DIFF
--- a/site/setup.md
+++ b/site/setup.md
@@ -9,7 +9,12 @@ Access your AMS 2021 Python Workshop JupyterHub learning environment here: **pla
 
 To meet the educational objectives of this workshop, we will be employing Jupyter and JupyterHub computational notebook technologies hosted on the [Unidata Science Gateway](https://science-gateway.unidata.ucar.edu/ "Unidata Science Gateway"). Jupyter notebooks enable interactive Python code development supplemented with explanatory text and figures right in your web browser. No special software is necessary. All you need to do as a workshop attendee to access your tutorial workspace is navigate to **place-holder** and login with your GitHub credentials. (A free GitHub account can be obtain [**here**](https://github.com/join)). Once logged in, Unidata staff have configured your workspace to ensure you have a smooth workshop experience. Your instructors will guide you through the educational Jupyter notebook material.
 
-## Troubleshooting And Seeking Help
+## Saving Your Material After Workshop
+
+The material that will be presented to you during the workshop will be available at [workshop website](https://unidata.github.io/pyaos-ams-2021/index.html) and [accompanying repository](https://github.com/Unidata/pyaos-ams-2021/). **The JupyterHub that you will be using for this workshop will only be available until midnight mountain time on Tuesday, January 19**. [Please save any work you wish to save by that time](https://jupyterlab.readthedocs.io/en/stable/user/files.html?highlight=download#uploading-and-downloading).
+
+
+## Troubleshooting and Seeking Help
 
 If you run into problems, you can:
 

--- a/site/setup.md
+++ b/site/setup.md
@@ -7,13 +7,14 @@ Access your AMS 2021 Python Workshop JupyterHub learning environment here: **pla
 
 ## Longer Explanation
 
-To meet the educational objectives of this workshop, we will be employing Jupyter and JupyterHub computational notebook technologies hosted on the [Unidata Science Gateway](https://science-gateway.unidata.ucar.edu/ "Unidata Science Gateway"). Jupyter notebooks enable interactive Python code development supplemented with explanatory text and figures right in your web browser. No special software is necessary. All you need to do as a workshop attendee to access your tutorial workspace is navigate to **place-holder** and login with your GitHub credentials. (A free GitHub account can be obtain here: https://github.com/join). Once logged in, Unidata staff have configured your workspace to ensure you have a smooth workshop experience. Your instructors will guide you through the educational Jupyter notebook material.
+To meet the educational objectives of this workshop, we will be employing Jupyter and JupyterHub computational notebook technologies hosted on the [Unidata Science Gateway](https://science-gateway.unidata.ucar.edu/ "Unidata Science Gateway"). Jupyter notebooks enable interactive Python code development supplemented with explanatory text and figures right in your web browser. No special software is necessary. All you need to do as a workshop attendee to access your tutorial workspace is navigate to **place-holder** and login with your GitHub credentials. (A free GitHub account can be obtain [**here**](https://github.com/join)). Once logged in, Unidata staff have configured your workspace to ensure you have a smooth workshop experience. Your instructors will guide you through the educational Jupyter notebook material.
 
 ## Troubleshooting And Seeking Help
 
 If you run into problems, you can:
 
 - Ask your instructor for help
+- Join one of the [daily office hours](https://unidata.github.io/pyaos-ams-2021/agenda.html#asynchronous-workshop-br-span-class-subhead-throughout-the-week-of-ams-br-january-10th-january-14th-2021-span)
 - [Start a new discussion on the repository for this workshop](https://github.com/Unidata/pyaos-ams-2021/discussions/categories/jupyterhub-trouble "Ask for help").
 
 ## Acknowledgments

--- a/site/setup.md
+++ b/site/setup.md
@@ -1,22 +1,22 @@
 Workshop Environment
 ====================
 
-# Quick Start
+## Quick Start
 
 Access your AMS 2021 Python Workshop JupyterHub learning environment here: **place-holder**.
 
-# Longer Explanation
+## Longer Explanation
 
 To meet the educational objectives of this workshop, we will be employing Jupyter and JupyterHub computational notebook technologies hosted on the [Unidata Science Gateway](https://science-gateway.unidata.ucar.edu/ "Unidata Science Gateway"). Jupyter notebooks enable interactive Python code development supplemented with explanatory text and figures right in your web browser. No special software is necessary. All you need to do as a workshop attendee to access your tutorial workspace is navigate to **place-holder** and login with your GitHub credentials. (A free GitHub account can be obtain here: https://github.com/join). Once logged in, Unidata staff have configured your workspace to ensure you have a smooth workshop experience. Your instructors will guide you through the educational Jupyter notebook material.
 
-# Troubleshooting And Seeking Help
+## Troubleshooting And Seeking Help
 
 If you run into problems, you can:
 
 - Ask your instructor for help
 - [Start a new discussion on the repository for this workshop](https://github.com/Unidata/pyaos-ams-2021/discussions/categories/jupyterhub-trouble "Ask for help").
 
-# Acknowledgments
+## Acknowledgments
 
 The JupyterHub for this workshop is part of the [National Science Foundation](https://www.nsf.gov/ "National Science Foundation") (NSF) funded [Unidata Science Gateway](https://doi.org/10.5065/688s-2w73 "Unidata Science Gateway") (under NSF Award [1901712](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1901712)).
 We thank Andrea Zonca (San Diego Supercomputing Center), Jeremy Fischer (Indiana University), the NSF funded [Jetstream](https://dx.doi.org/10.1145/2792745.2792774) team, and the NSF funded XSEDE [Extended Collaborative Support Service (ECSS)](https://doi.org/10.1007/978-3-319-32243-8_1) program for assistance with this JupyterHub.


### PR DESCRIPTION
- changed section headers from `#` to `##`.  Single # headers are really meant for page headers, not section headers.  Using # headers was causing a weird heading spacing for the navigation bar at the top of the website.  Also, the sections on the setup webpage where not spaced great, and inconsistent with other pages.

**Before:**
![Screen Shot 2021-01-08 at 11 08 58 PM](https://user-images.githubusercontent.com/21114460/104084696-9a7b8600-5206-11eb-97f9-db704cf2d3a9.png)


**After:**
![Screen Shot 2021-01-08 at 11 09 59 PM](https://user-images.githubusercontent.com/21114460/104084700-a6674800-5206-11eb-9c3a-0bb6016144dc.png)


- Also made the github url clickable
- added a bullet point about joining office hours for the 'troubleshooting' section